### PR TITLE
Add HTTP Support

### DIFF
--- a/google-action.html
+++ b/google-action.html
@@ -39,11 +39,18 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         <input id="node-input-url" type="text" placeholder="/">
     </div>
     <div class="form-row">
-        <label for="node-input-key"><i class="fa fa-tag"></i> SSL Private Key File</span></label>
+        <label for="node-input-protocol"><i class="fa fa-tag"></i> Protocol</span></label>
+        <select id="node-input-protocol">
+            <option value="http">HTTP</option>
+            <option value="https">HTTPS</option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label id="node-input-label-key" for="node-input-key"><i class="fa fa-tag"></i> SSL Private Key File</span></label>
         <input id="node-input-key" type="text" placeholder="/path/on/server/to/private.key">
     </div>
     <div class="form-row">
-        <label for="node-input-cert"><i class="fa fa-tag"></i> SSL Certificate File</span></label>
+        <label id="node-input-label-cert" for="node-input-cert"><i class="fa fa-tag"></i> SSL Certificate File</span></label>
         <input id="node-input-cert" type="text" placeholder="/path/on/server/to/certificate.crt">
     </div>
 </script>
@@ -60,6 +67,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         <dd>port number for server to listen on </dd>
         <dt>url <span class="property-type"> string</span><dt>
         <dd>url for server to listen on </dd>
+        <dt>protocol <span class="property-type"> string</span><dt>
+        <dd>protocol for the connection </dd>
         <dt>SSL private key file <span class="property-type">filename </span><dt>
         <dd>full path to SSL private key file on Node Red server</dd>
         <dt>SSl certificate file <span class="property-type">filename </span><dt>
@@ -139,8 +148,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             topic: {value:""},
             port: {value:"8081",required:true, validate: RED.validators.number()},
             url: {value:"/", required:true},
-            key: {value:"", requred:true},
-            cert: {value: "", required:true}
+            protocol: {value:"https", required:true},
+            key: {value:"" },
+            cert: {value:"" }
         },
         inputs:0,
         outputs:1,
@@ -154,6 +164,20 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         },
         labelStyle: function() {
             return this.name?"node_label_italic":"";
+        },
+        oneditprepare: function() {
+
+            $("#node-input-protocol").change(function() {
+                    var protocol = $("#node-input-protocol option:selected").val();
+                    if (protocol == "https") {
+                        $("#node-input-key, #node-input-cert, #node-input-label-cert, #node-input-label-key").show();
+                    } else {
+                        $("#node-input-key, #node-input-cert, #node-input-label-cert, #node-input-label-key").hide();
+                    }
+                });
+
+            $("#node-input-protocol").val(this.protocol);
+            $("#node-input-protocol").change();
         }
     });
 

--- a/google-action.js
+++ b/google-action.js
@@ -50,6 +50,7 @@ module.exports = function(RED) {
         node.port = n.port || 8081;
         node.key = n.key || '';
         node.cert = n.cert || '';
+        node.protocol = n.protocol || 'https';
 
         // Create new http server to listen for requests
         var expressApp = express();

--- a/google-action.js
+++ b/google-action.js
@@ -31,6 +31,7 @@ module.exports = function(RED) {
 
     const express = require('express');
     const https = require("https");
+    const http = require("http");
     const fs = require('fs');
 
     const bodyParser = require('body-parser');
@@ -50,15 +51,21 @@ module.exports = function(RED) {
         node.key = n.key || '';
         node.cert = n.cert || '';
 
-        const options = {
-            key: fs.readFileSync(node.key),
-            cert: fs.readFileSync(node.cert)
-        };
-
-                // Create new http server to listen for requests
+        // Create new http server to listen for requests
         var expressApp = express();
         expressApp.use(bodyParser.json({ type: 'application/json' }));
-        node.httpServer = https.createServer(options, expressApp);
+
+        if (node.protocol === "https") {
+            const options = {
+                key: fs.readFileSync(node.key),
+                cert: fs.readFileSync(node.cert)
+            };
+
+            node.httpServer = https.createServer(options, expressApp);
+        } else {
+            node.httpServer = http.createServer(expressApp);
+        }
+
 
         // Handler for requests
         expressApp.all(node.url, (request, response) => {


### PR DESCRIPTION
This is useful for when you have nodered behind a ssl terminating reverse proxy, such as traefik, or nginx.

There's a new UI option for selecting 'protocol' (http or https). When https is selected, the cert and key text boxes are visible, and they are hidden when http is selected, since they're not relevant for http.

Fixes issue #11 